### PR TITLE
fix name issue in 2D PCA plot

### DIFF
--- a/R/fct_04_pca.R
+++ b/R/fct_04_pca.R
@@ -147,12 +147,13 @@ PCA_plot <- function(data,
 
   plot_PCA <- ggplot2::ggplot(
     data = pcaData,
-    ggplot2::aes_string(
-      x = paste0("PC", PCAx),
-      y = paste0("PC", PCAy),
-      color = selected_color,
-      shape = selected_shape,
-      group = selected_shape
+    mapping = ggplot2::aes(
+      x = pcaData[[paste0("PC", PCAx)]],
+      y = pcaData[[paste0("PC", PCAy)]],
+      color = pcaData[[selected_color]],
+      shape = pcaData[[selected_shape]],
+      group = pcaData[[selected_shape]],
+      text = rownames(pcaData) # This line specifies the tooltip content
     )
   ) +
     # Preferred shapes
@@ -278,7 +279,7 @@ PCA_plot_3d <- function(data,
 
   # selected principal components
   PCAxyz <- c(as.integer(PCAx), as.integer(PCAy), as.integer(PCAz))
-  percentVar <- round(100 * summary(pca.object)$importance[2, PCAxyz], 0)
+  percentVar <- get_pc_variance(data)[PCAxyz]
   plot_PCA <- plotly::plot_ly(pcaData,
     x = pcaData[, as.integer(PCAx)],
     y = pcaData[, as.integer(PCAy)],
@@ -299,7 +300,7 @@ PCA_plot_3d <- function(data,
     )
   plot_PCA <- plotly::layout(
     p = plot_PCA,
-    legend = list(title = list(text = paste0(selected_color, " ", selected_shape))),
+    legend = list(title = list(text = paste0("selected_color: ",selected_color, " selected_shape: ", selected_shape))),
     plot_bgcolor = "#e5ecf6",
     scene = list(
       xaxis = list(

--- a/R/mod_04_pca.R
+++ b/R/mod_04_pca.R
@@ -327,7 +327,7 @@ mod_04_pca_server <- function(id, pre_process, idep_data) {
       )
     })
     output$interactive_pca_plot_obj <- plotly::renderPlotly({
-      plotly::ggplotly(pca_plot())
+      plotly::ggplotly(pca_plot(), tooltip = "text")
     })
     output$pca_plot_obj <- renderPlot({
       req(pca_plot())


### PR DESCRIPTION
This fixes the #493, 

Though I notice this error on PCA with both my branch and main 

output$pca_plot_obj <- renderPlot({
      req(pca_plot())
      print(pca_plot())
    })

Warning: Error in : C stack usage  1917728 is too close to the limit
  163: <Anonymous>
  162: stop
  161: value[[3L]]
  160: tryCatchOne
  159: tryCatchList
  158: tryCatch
  157: do
  156: hybrid_chain
  128: drawPlot
  114: <reactive:plotObj>
   98: drawReactive
   85: renderFunc
   84: output$pca-pca_plot_obj
    3: runApp
    2: print.shiny.appobj
    1: <Anonymous>