### PR TITLE
fix naming issue and remove non-interactive

### DIFF
--- a/R/fct_04_pca.R
+++ b/R/fct_04_pca.R
@@ -147,13 +147,13 @@ PCA_plot <- function(data,
 
   plot_PCA <- ggplot2::ggplot(
     data = pcaData,
-    mapping = ggplot2::aes(
-      x = pcaData[[paste0("PC", PCAx)]],
-      y = pcaData[[paste0("PC", PCAy)]],
-      color = pcaData[[selected_color]],
-      shape = pcaData[[selected_shape]],
-      group = pcaData[[selected_shape]],
-      text = rownames(pcaData) # This line specifies the tooltip content
+    mapping = ggplot2::aes_string(
+      x = paste0("PC", PCAx),
+      y = paste0("PC", PCAy),
+      color = selected_color,
+      shape = selected_shape,
+      group = selected_shape,
+      text = "rownames(pcaData)" # Add this line to specify the tooltip content
     )
   ) +
     # Preferred shapes
@@ -300,7 +300,7 @@ PCA_plot_3d <- function(data,
     )
   plot_PCA <- plotly::layout(
     p = plot_PCA,
-    legend = list(title = list(text = paste0("selected_color: ",selected_color, " selected_shape: ", selected_shape))),
+    legend = list(title = list(text = "Names")),
     plot_bgcolor = "#e5ecf6",
     scene = list(
       xaxis = list(

--- a/R/mod_04_pca.R
+++ b/R/mod_04_pca.R
@@ -211,14 +211,6 @@ mod_04_pca_ui <- function(id) {
             ),
             ottoPlots::mod_download_figure_ui(ns("download_interactive_pca")),
             br(),
-            h5("\n Non-Interactive Plot"),
-            plotOutput(
-              outputId = ns("pca_plot_obj"),
-              width = "100%",
-              height = "600px"
-            ),
-            ottoPlots::mod_download_figure_ui(ns("download_pca")),
-            br(),
             br(),
             shiny::textOutput(
               outputId = ns("pc_correlation")
@@ -329,11 +321,6 @@ mod_04_pca_server <- function(id, pre_process, idep_data) {
     output$interactive_pca_plot_obj <- plotly::renderPlotly({
       plotly::ggplotly(pca_plot(), tooltip = "text")
     })
-    output$pca_plot_obj <- renderPlot({
-      req(pca_plot())
-      print(pca_plot())
-    })
-
     # Download Button
     download_interactive_pca <- ottoPlots::mod_download_figure_server(
       id = "download_interactive_pca",
@@ -353,25 +340,6 @@ mod_04_pca_server <- function(id, pre_process, idep_data) {
         tab = id
       )
     )
-    download_pca <- ottoPlots::mod_download_figure_server(
-      id = "download_pca",
-      filename = "pca_plot",
-      figure = reactive({
-        pca_plot()
-      }),
-      label = "",
-      width = get_plot_width(
-        client_data = session$clientData,
-        plot_name = "pca_plot_obj",
-        tab = id
-      ),
-      height = get_plot_height(
-        client_data = session$clientData,
-        plot_name = "pca_plot_obj",
-        tab = id
-      )
-    )
-
     # PC Factor Correlation ---------
     output$pc_correlation <- renderText({
       req(!is.null(pre_process$data()))


### PR DESCRIPTION

Looks great. I merged it in. Only minor issue is the title of the legend. "pcaData[[selected_color]]".


Yes, we can get rid of the non-interactive version.