### PR TITLE
Enhanced Number Parsing & Handling of NA Values

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -10,6 +10,13 @@ app_server <- function(input, output, session) {
   options(warn = -1) # turn off warning
   pdf(file = NULL)
 
+  FILE_SIZE_LIMIT_MB <<- as.numeric(Sys.getenv("IDEP_FILE_SIZE_LIMIT")[1])
+
+  # If environment variable not set or not a valid number, default to 5
+  if (is.na(FILE_SIZE_LIMIT_MB) || FILE_SIZE_LIMIT_MB <= 0) {
+    FILE_SIZE_LIMIT_MB <<- 5
+  }
+
   # define where database is located
   db_ver <<- "data107"
   db_url <<- "http://bioinformatics.sdstate.edu/data/"

--- a/R/fct_01_load_data.R
+++ b/R/fct_01_load_data.R
@@ -153,7 +153,7 @@ input_data <- function(expression_file,
     in_file_data <- demo_data_file
   }
 
-  if (bytes_to_MB_decimal(expression_file$size) > FILE_SIZE_LIMIT_MB) {
+  if (!is.null(expression_file) && bytes_to_MB_decimal(expression_file$size) > FILE_SIZE_LIMIT_MB) {
     return(
       list(
         data = NULL,

--- a/R/fct_01_load_data.R
+++ b/R/fct_01_load_data.R
@@ -107,7 +107,11 @@ safe_numeric_conversion <- function(x) {
   ifelse(is.na(converted), NA, converted)
 }
 
-
+# SI System (Decimal)
+bytes_to_MB_decimal <- function(bytes) {
+  MB <- bytes / (10^6)
+  return(MB)
+}
 
 
 #' Load basic data information
@@ -128,7 +132,8 @@ safe_numeric_conversion <- function(x) {
 #'
 #' @export
 #' @return This returns a list that contains the expression data,
-#' the sample information, and rows that are removed due to not able to read them.
+#' the sample information, message that show been shown to the user,
+#' and rows that are removed due to not able to read them.
 #' if no rows are removed then NULL is returned for that variable in the list.
 #' If there is no experiment file it
 #' only returns the expression data.
@@ -146,6 +151,20 @@ input_data <- function(expression_file,
     return(NULL)
   } else if (go_button > 0) { # use demo data
     in_file_data <- demo_data_file
+  }
+
+  if (bytes_to_MB_decimal(expression_file$size) > FILE_SIZE_LIMIT_MB) {
+    return(
+      list(
+        data = NULL,
+        sample_info = NULL,
+        remove_data = NULL,
+        message = paste(
+          "File size exceeds the limit of", FILE_SIZE_LIMIT_MB,
+          "MB. Please upload a smaller file. Look on GitHub how to run locally and change file size limit."
+        )
+      )
+    )
   }
 
   isolate({
@@ -245,6 +264,7 @@ input_data <- function(expression_file,
     return(list(
       data = data,
       sample_info = NULL,
+      message = NULL,
       remove_data = data_na_rows
     ))
   } else if (go_button > 0) {
@@ -263,6 +283,7 @@ input_data <- function(expression_file,
     return(list(
       sample_info = sample_info_demo,
       data = data,
+      message = NULL,
       remove_data = data_na_rows
     ))
   }
@@ -358,12 +379,14 @@ input_data <- function(expression_file,
       }
       return(list(
         data = data,
+        message = NULL,
         sample_info = t(expr),
         remove_data = data_na_rows
       ))
     } else {
       return(list(
         data = data,
+        message = NULL,
         remove_data = data_na_rows
       ))
     }

--- a/R/fct_01_load_data.R
+++ b/R/fct_01_load_data.R
@@ -101,6 +101,13 @@ gene_info <- function(converted,
 }
 
 
+# Safe conversion function
+safe_numeric_conversion <- function(x) {
+  converted <- suppressWarnings(as.numeric(gsub(",", "", x)))
+  ifelse(is.na(converted), NA, converted)
+}
+
+
 
 
 #' Load basic data information
@@ -151,7 +158,10 @@ input_data <- function(expression_file,
       data <- readxl::read_excel(in_file_data)
       data <- data.frame(data)
     } else {
-      data <- read.csv(in_file_data, quote = "", comment.char = "")
+       data <- read.csv(in_file_data,
+         header = TRUE, stringsAsFactors = FALSE,
+         quote = "\"", comment.char = ""
+       )
     }
     # Tab-delimented if not CSV
     if (ncol(data) <= 2) {
@@ -160,6 +170,8 @@ input_data <- function(expression_file,
         sep = "\t",
         header = TRUE,
         quote = "",
+        stringsAsFactors = FALSE,
+        quote = "\"",
         comment.char = ""
       )
     }
@@ -225,7 +237,8 @@ input_data <- function(expression_file,
   if (is.null(in_file_expr) && go_button == 0) {
     return(list(
       data = data,
-      sample_info = NULL
+      sample_info = NULL,
+      remove_data = data_na_rows
     ))
   } else if (go_button > 0) {
     sample_info_demo <- NULL
@@ -242,7 +255,8 @@ input_data <- function(expression_file,
     }
     return(list(
       sample_info = sample_info_demo,
-      data = data
+      data = data,
+      remove_data = data_na_rows
     ))
   }
 
@@ -337,11 +351,13 @@ input_data <- function(expression_file,
       }
       return(list(
         data = data,
-        sample_info = t(expr)
+        sample_info = t(expr),
+        remove_data = data_na_rows
       ))
     } else {
       return(list(
-        data = data
+        data = data,
+        remove_data = data_na_rows
       ))
     }
   })

--- a/R/fct_01_load_data.R
+++ b/R/fct_01_load_data.R
@@ -160,7 +160,8 @@ input_data <- function(expression_file,
     } else {
        data <- read.csv(in_file_data,
          header = TRUE, stringsAsFactors = FALSE,
-         quote = "\"", comment.char = ""
+         quote = "\"", comment.char = "",
+         blank.lines.skip = TRUE
        )
     }
     # Tab-delimented if not CSV
@@ -169,10 +170,10 @@ input_data <- function(expression_file,
         in_file_data,
         sep = "\t",
         header = TRUE,
-        quote = "",
         stringsAsFactors = FALSE,
         quote = "\"",
-        comment.char = ""
+        comment.char = "",
+        blank.lines.skip = TRUE
       )
     }
     # Convert all columns after the first one to numeric using the safe function
@@ -185,11 +186,17 @@ input_data <- function(expression_file,
     })
     # Rows with at least one NA value
     rows_with_na <- apply(data, MARGIN = 1, FUN = function(x) any(is.na(x)))
-    
     # Extract rows with NA values
     data_na_rows <- data[rows_with_na, ]
     if (nrow(data_na_rows) > 0) {
       data_na_rows$reason_for_removal <- "At least one value couldn't be read as a number in this row.\nThey will show as blanket."
+      colnames(data_na_rows)[1] <- "user_gene_id"
+      # Add row numbers as a new column
+      data_na_rows$row_number <- as.numeric(row.names(data_na_rows))
+      # Reorder columns to make row_number the first column
+      data_na_rows <- data_na_rows[, c("row_number", setdiff(colnames(data_na_rows), "row_number"))]
+      # Remove rows where user_gene_id is blank or NA
+      data_na_rows <- data_na_rows[!(is.na(data_na_rows$user_gene_id) | data_na_rows$user_gene_id == ""), ]
     } else {
       data_na_rows <- NULL
     }

--- a/R/mod_01_load_data.R
+++ b/R/mod_01_load_data.R
@@ -570,6 +570,17 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
     })
 
     observe({
+      req(!is.null(loaded_data()$message))
+
+      showNotification(
+        ui = loaded_data()$message,
+        id = "file_size_limit_error",
+        duration = NULL,
+        type = "error"
+      )
+    })
+
+    observe({
       req(!is.null(loaded_data()$data) && any(apply(loaded_data()$data, 2, function(col) all(col == 0))))
 
       showNotification(

--- a/R/mod_01_load_data.R
+++ b/R/mod_01_load_data.R
@@ -874,6 +874,7 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
       data_file_format = reactive(input$data_file_format),
       no_fdr = reactive(input$no_fdr),
       select_org = reactive(input$select_org),
+      remove_data = reactive(loaded_data()$remove_data),
       gmt_file = reactive(input$gmt_file),
       sample_info = reactive(loaded_data()$sample_info),
       all_gene_info = reactive(conversion_info()$all_gene_info),

--- a/R/mod_02_pre_process.R
+++ b/R/mod_02_pre_process.R
@@ -525,6 +525,12 @@ mod_02_pre_process_ui <- function(id) {
             DT::dataTableOutput(outputId = ns("examine_data"))
           ),
           tabPanel(
+            title = "Data Removed",
+            h5("These rows were removed due to at least value be unable to read."),
+            br(),
+            DT::dataTableOutput(outputId = ns("examine_data_remove"))
+          ),
+          tabPanel(
             title = "Info",
             includeHTML(app_sys("app/www/help_preprocess.html"))
           ),

--- a/R/mod_02_pre_process.R
+++ b/R/mod_02_pre_process.R
@@ -949,6 +949,26 @@ mod_02_pre_process_server <- function(id, load_data, tab) {
       )
     })
 
+    output$examine_data_remove <- DT::renderDataTable({
+      # Check if the data is NULL
+      if (is.null(load_data$remove_data())) {
+        return(DT::datatable(data.frame(Message = "No rows removed"),
+          rownames = FALSE,
+          options = list(autoWidth = TRUE, searching = FALSE, paging = FALSE)
+        ))
+      }
+
+      # If not NULL, render the datatable as usual
+      DT::datatable(
+        load_data$remove_data(),
+        options = list(
+          pageLength = 10,
+          scrollX = "400px"
+        ),
+        rownames = FALSE
+      )
+    })
+
     # Individual plot data ------------
     individual_data <- reactive({
       req(!is.null(processed_data()$data))


### PR DESCRIPTION
**Description:**

Improved the ability to read strings like "1,120" as numbers. This enhancement has been applied to both CSV and tab formats to maintain consistency across workflows.

Resolved the issue reported in #569 

**Handling of NA Values:**

Proposed Approach: If a cell contains an NA value, we should consider removing the corresponding gene (row). The user will be informed that a cell had an NA value, leading to the removal of the associated row.

To provide transparency, I've integrated a table that displays rows removed due to values that couldn't be interpreted as numbers (resulting in NA). This feature will be especially useful in cases where the input file might contain unexpected content, such as a stray word.

Addressed an edge case where the 'remove data' dataframe might have 0 rows. Implemented a check to handle this scenario gracefully.

Introduced a user-friendly message to indicate when no rows are removed.

**Documentation:**

Updated documentation to reflect these changes.


**Testing:**

Verified the changes using demo data and the dataset from issue #569.

Written by ChatGPT cause work smarter not harder.