### PR TITLE
cluster auto change issue

### DIFF
--- a/R/mod_11_enrichment.R
+++ b/R/mod_11_enrichment.R
@@ -380,7 +380,7 @@ mod_11_enrichment_server <- function(id,
       selected <- choices[1]
       updateSelectInput(
         session = session,
-        inputId = "select_cluster",
+        inputId = ns("select_cluster"),
         selected = selected
       )
     })


### PR DESCRIPTION
fix issue #523 . User input for cluster number will stay as selected in the plot tab and other enrichment tabs (within clustering tab).