### PR TITLE
PCA Consistency Fix 2

### DIFF
--- a/R/fct_04_pca.R
+++ b/R/fct_04_pca.R
@@ -301,7 +301,7 @@ PCA_plot_3d <- function(data,
     ),
     type = "scatter3d",
     mode = "markers",
-    colors = unique(color_palette[as.factor(pcaData$Names)])
+    colors = color_palette
     )
   plot_PCA <- plotly::layout(
     p = plot_PCA,


### PR DESCRIPTION
Issue #682 :
Changed colors of PCA/3D plot to match only the palette generated in the function, as there were still some inconsistencies.