### PR TITLE
Download Enriched Genes Fix

### DIFF
--- a/R/mod_05_deg.R
+++ b/R/mod_05_deg.R
@@ -719,6 +719,13 @@ mod_05_deg_server <- function(id, pre_process, idep_data, load_data, tab) {
           ,
           c("gene_id", setdiff(names(list_genes_df), "gene_id"))
         ]
+        
+        # Filter out unenriched genes (not up or down regulated)
+        list_genes_df <- list_genes_df[apply(
+          as.data.frame(list_genes_df[ , -1]), 1, 
+          function(row) any(row %in% c("Up", "Down"))
+        ), ]
+        
         write.csv(list_genes_df, file, row.names = FALSE)
       }
     )
@@ -727,7 +734,7 @@ mod_05_deg_server <- function(id, pre_process, idep_data, load_data, tab) {
       req(!is.null(deg$limma$results))
       downloadButton(
         outputId = ns("sig_genes_download"),
-        "Results & data"
+        "Enriched Gene List"
       )
     })
 


### PR DESCRIPTION
## Issue #578 :
* Fixed remaining additions mentioned in later comments on this issue

* Download button name changed from "Results & data" to "Enriched Gene List" as suggested, since there is already a button labeled "Results & data" on this tab.

* Added a few lines to filter out "unenriched" genes, only keeping those that are up and down regulated in the downloaded file.