### PR TITLE
Network Gene Name Fix

### DIFF
--- a/R/fct_09_network.R
+++ b/R/fct_09_network.R
@@ -173,7 +173,7 @@ get_network <- function(select_wgcna_module,
   module <- unlist(strsplit(select_wgcna_module, " "))[2]
   module_colors <- wgcna$dynamic_colors
   in_module <- (module_colors == module)
-
+  
   if (select_wgcna_module == "Entire network") {
     in_module <- rep(TRUE, length(in_module))
   }
@@ -214,9 +214,15 @@ get_network <- function(select_wgcna_module,
 
   if (!is.null(probe_to_gene)) {
     ix <- match(colnames(net), probe_to_gene[, 1])
-    colnames(net) <- probe_to_gene[ix, 2]
+    colnames(net) <- dplyr::case_when(
+      !is.na(probe_to_gene[ix, 2]) ~ probe_to_gene[ix, 2],
+      TRUE ~ colnames(net)
+    )
     ix <- match(rownames(net), probe_to_gene[, 1])
-    rownames(net) <- probe_to_gene[ix, 2]
+    rownames(net) <- dplyr::case_when(
+      !is.na(probe_to_gene[ix, 2]) ~ probe_to_gene[ix, 2],
+      TRUE ~ rownames(net)
+    )
   }
 
   return(net)
@@ -240,7 +246,6 @@ get_network_plot <- function(adjacency_matrix, edge_threshold) {
     adjacency_matrix[i, i] <- FALSE
   }
   graph <- igraph::graph_from_adjacency_matrix(adjacency_matrix, mode = "undirected")
-
   # http://www.kateto.net/wp-content/uploads/2016/01/NetSciX_2016_Workshop.pdf
   net_plot <- function() {
     plot(

--- a/R/mod_09_network.R
+++ b/R/mod_09_network.R
@@ -179,6 +179,9 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
     })
 
     wgcna <- reactive({
+      req(!is.na(input$n_genes_network))
+      req(!is.na(input$min_module_size))
+      req(!is.na(input$soft_power))
       req(!is.null(pre_process$data()))
       withProgress(message = "Runing WGCNA ...", {
         incProgress(0.2)
@@ -232,7 +235,14 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
 
     adj_matrix <- reactive({
       req(!is.null(input$select_wgcna_module))
+      req(!is.na(input$network_layout))
+      req(!is.na(input$edge_threshold))
+      req(!is.na(input$top_genes_network))
+      req(!is.na(input$n_genes_network))
+      req(!is.na(input$min_module_size))
+      req(!is.na(input$soft_power))
       req(!is.null(wgcna()))
+      
       tem <- input$network_layout
       tem <- input$edge_threshold
       get_network(
@@ -247,7 +257,14 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
 
     observe({
       req(!is.null(input$select_wgcna_module))
+      req(!is.na(input$network_layout))
+      req(!is.na(input$edge_threshold))
+      req(!is.na(input$top_genes_network))
+      req(!is.na(input$n_genes_network))
+      req(!is.na(input$min_module_size))
+      req(!is.na(input$soft_power))
       req(!is.null(wgcna()))
+
       tem = input$network_layout
       network$network_plot <- get_network_plot(
         adj_matrix(),


### PR DESCRIPTION
## Issue #679 :
* Nodes in networks plots will now always have a name attached
* Previously, gene names from uploaded data were swapped with ensembl IDs and Symbols, but these don't always match what is submitted, depending on the user's observed ID system
* Now, if uploaded IDs do not have a match, they are kept instead of switched to NA, leaving the submitted ID in the adjacency matrix and network plots

**Extra:** Added extra req() statements for WGCNA data, adjacency matrix, and network plot to avoid edge cases, which previously crashed the app if Network inputs were NA