### PR TITLE
Network and Module Plot Downloads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Imports:
     GetoptLong,
     ggalt,
     ggplot2,
+    ggraph,
     golem (>= 0.3.1),
     graphics,
     grDevices,

--- a/R/fct_09_network.R
+++ b/R/fct_09_network.R
@@ -247,15 +247,16 @@ get_network_plot <- function(adjacency_matrix, edge_threshold) {
   }
   graph <- igraph::graph_from_adjacency_matrix(adjacency_matrix, mode = "undirected")
   # http://www.kateto.net/wp-content/uploads/2016/01/NetSciX_2016_Workshop.pdf
-  net_plot <- function() {
-    plot(
-      graph,
-      vertex.label.color = "black",
-      vertex.label.dist = 3,
-      vertex.size = 7
-    )
-  }
-  return(net_plot)
+  ggraph_obj <- ggraph::ggraph(graph, layout = "fr") +
+    ggraph::geom_edge_link(edge_colour = "darkgrey") +
+    ggraph::geom_node_point(shape = 21, 
+                            size = 3, 
+                            fill = "gold", 
+                            color = "black",
+                            stroke = 0.5) +
+    ggraph::geom_node_text(ggplot2::aes(label = name), repel = TRUE, size = 4)+
+    ggplot2::theme_void()
+  return(ggraph_obj)
 }
 
 

--- a/R/fct_09_network.R
+++ b/R/fct_09_network.R
@@ -250,11 +250,13 @@ get_network_plot <- function(adjacency_matrix, edge_threshold) {
   ggraph_obj <- ggraph::ggraph(graph, layout = "fr") +
     ggraph::geom_edge_link(edge_colour = "darkgrey") +
     ggraph::geom_node_point(shape = 21, 
-                            size = 3, 
+                            size = 3.5, 
                             fill = "gold", 
                             color = "black",
                             stroke = 0.5) +
-    ggraph::geom_node_text(ggplot2::aes(label = name), repel = TRUE, size = 4)+
+    ggraph::geom_node_text(ggplot2::aes(label = name), 
+                           repel = TRUE, 
+                           size = 4.5)+
     ggplot2::theme_void()
   return(ggraph_obj)
 }

--- a/R/mod_09_network.R
+++ b/R/mod_09_network.R
@@ -66,6 +66,11 @@ mod_09_network_ui <- function(id) {
             outputId = ns("download_selected_WGCNA_module"),
             "Selected module"
           ),
+          tippy::tippy_this(
+            ns("download_selected_WGCNA_module"),
+            "Download gene information for the selected module",
+            theme = "light-border"
+          ),
           conditionalPanel(
             condition = "input.network_tabs == 'Heatmap'",
             downloadButton(
@@ -207,7 +212,7 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
       req(!is.na(input$min_module_size))
       req(!is.na(input$soft_power))
       req(!is.null(pre_process$data()))
-      withProgress(message = "Runing WGCNA ...", {
+      withProgress(message = "Running WGCNA ...", {
         incProgress(0.2)
         get_wgcna(
           data = pre_process$data(),
@@ -243,7 +248,12 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
     })
     output$download_selected_WGCNA_module <- downloadHandler(
       filename <- function() {
-        paste0("module_", input$select_wgcna_module, ".csv")
+        paste0(
+          sub("\\d\\.\\s*([a-zA-Z]+)\\s*\\(.*\\)", 
+              "\\1",
+              input$select_wgcna_module),
+          "_module_network_genes.csv"
+        )
       },
       content <- function(file) {
         write.csv(module_csv_data_filter(), file, row.names = FALSE)
@@ -256,7 +266,7 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
     })
     
     output$dl_module_plot <- downloadHandler(
-      filename = "module_dendrogram.png", 
+      filename = "network_dendrogram.png", 
       content = function(file) {
         req(!is.null(wgcna()))
         png(file, res = 360, width = 10, height = 6, units = "in")
@@ -309,7 +319,12 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
 
     output$download_module_network <- downloadHandler(
       filename = function() {
-        paste0("module_network_", input$select_wgcna_module, ".csv")
+        paste0(
+          sub("\\d\\.\\s*([a-zA-Z]+)\\s*\\(.*\\)", 
+              "\\1",
+              input$select_wgcna_module),
+          "_module_network.csv"
+        )
       },
       content = function(file) {
         # convert adjacency matrix to edge list, i.e. from wide to long format
@@ -328,7 +343,7 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
 
     dl_network_plot <- ottoPlots::mod_download_figure_server(
      id = "dl_network_plot",
-     filename = "module_network",
+     filename = "module_network_plot",
      figure = reactive({
        network$network_plot
      })

--- a/R/mod_09_network.R
+++ b/R/mod_09_network.R
@@ -123,15 +123,18 @@ mod_09_network_ui <- function(id) {
             ),
             br(),
             plotOutput(outputId = ns("module_network")),
-            downloadButton(outputId = ns("download_module_network"), "Network file"),
-            tippy::tippy_this(
-              ns("download_module_network"),
-              "This file can be imported to CytoScape or VisANT for further analysis.",
-              theme = "light-border"
-            ),
-            #ottoPlots::mod_download_figure_ui(
-            #  id = ns("dl_network_plot")
-            #)
+            div(
+              style = "display: flex; flex-wrap: wrap; gap: 5px",
+              downloadButton(outputId = ns("download_module_network"), "Network file"),
+              tippy::tippy_this(
+                ns("download_module_network"),
+                "This file can be imported to CytoScape or VisANT for further analysis.",
+                theme = "light-border"
+              ),
+              ottoPlots::mod_download_figure_ui(
+                id = ns("dl_network_plot")
+              )
+            )
           ),
           tabPanel(
             "Module Plot",
@@ -139,6 +142,10 @@ mod_09_network_ui <- function(id) {
               outputId = ns("module_plot"),
               width = "100%",
               height = "500px"
+            ),
+            downloadButton(
+              outputId = ns("dl_module_plot"),
+              label = "Module Plot"
             )
           ),
           tabPanel(
@@ -183,7 +190,7 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
 
     # Interactive heatmap environment
     network_env <- new.env()
-
+    
     output$list_wgcna_modules <- renderUI({
       req(!is.null(wgcna()))
       module_list <- get_wgcna_modules(wgcna = wgcna())
@@ -247,6 +254,15 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
       req(!is.null(wgcna()))
       get_module_plot(wgcna())
     })
+    
+    output$dl_module_plot <- downloadHandler(
+      filename = "module_dendrogram.png", 
+      content = function(file) {
+        req(!is.null(wgcna()))
+        png(file, res = 360, width = 10, height = 6, units = "in")
+        get_module_plot(wgcna())
+        dev.off()
+    })
 
     network <- reactiveValues(network_plot = NULL)
 
@@ -307,19 +323,20 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
     output$module_network <- renderPlot({
       req(!is.null(input$select_wgcna_module))
       req(!is.null(wgcna()))
-      network$network_plot()
+      network$network_plot
     })
 
-    # not working
-    #dl_network_plot <- ottoPlots::mod_download_figure_server(
-    #  id = "dl_network_plot",
-    #  filename = "module_network",
-    #  figure = reactive({
-    #    network$network_plot
-    #  })
-    #  ,
-    #  label = ""
-    #)
+    dl_network_plot <- ottoPlots::mod_download_figure_server(
+     id = "dl_network_plot",
+     filename = "module_network",
+     figure = reactive({
+       network$network_plot
+     })
+     ,
+     label = "Network plot",
+     width = 10,
+     height = 6
+    )
 
     network_query <- reactive({
       req(!is.null(input$select_wgcna_module))

--- a/dev/02_dev.R
+++ b/dev/02_dev.R
@@ -64,6 +64,7 @@ usethis::use_package("ottoPlots")
 usethis::use_package("ggupset")
 usethis::use_package("purrr")
 usethis::use_package("readxl")
+usethis::use_package("ggraph")
 
 ## Add modules ----
 ## Create a module infrastructure in R/


### PR DESCRIPTION
## Issue https://github.com/gexijin/idepGolem/issues/526 :
### First Commit
* Changed network plotting method from plot() function to ggraph() object
  * ggraph option is easier to work with and download than previous method
  * Leaves less white space on the Network tab than the previous method
* Added download options for both Network and Module plots
  * Module dendrogram class does not work with the ottoPlots package, so it currently only has .png format with fixed width
### Second Commit
* Made several file names dynamic
* Changed size of points and text on the new network plot to be readable

### **Note:** ggraph package should be installed prior to implementing this PR into the full app