### PR TITLE
Correct iDEP1.1 Link

### DIFF
--- a/R/mod_10_doc.R
+++ b/R/mod_10_doc.R
@@ -123,7 +123,7 @@ mod_10_doc_ui <- function(id) {
        the the R code on the DEG1 tab."),
       h4("Previous versions of iDEP are still useable:"),
       a("iDEP 1.13 with Ensembl Release 107, archived January 5, 2024 ",
-        href = "http://bioinformatics.sdstate.edu/idep96/"
+        href = "http://bioinformatics.sdstate.edu/idep11"
       ),
       br(),
       a("iDEP 0.96 with Ensembl Release 104, released on July 30, 2022 ",


### PR DESCRIPTION
## Issue #680 :
* Changed link for iDEP 1.1 in the About tab to the correct link rather than pointing to version 0.96

### Note: The link to iDEP 1.1 currently brings users to version 2.01. This needs to be corrected on the docker/server side of development