### PR TITLE
Enrichment Default Background

### DIFF
--- a/R/mod_01_load_data.R
+++ b/R/mod_01_load_data.R
@@ -819,7 +819,6 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
           (tab() != "Load Data"))
       
       removeNotification("select_first")
-      
     })
 
     # Show messages when on the Network tab or button is clicked ----

--- a/R/mod_02_pre_process.R
+++ b/R/mod_02_pre_process.R
@@ -637,6 +637,27 @@ mod_02_pre_process_server <- function(id, load_data, tab) {
 
       return(processed_data)
     })
+    
+    observe({
+      req(processed_data()$data_size[3] < 1000)
+      showNotification(
+        "Less than 1000 genes passed through the pre-processing filter. 
+         By default, all genes will be used as background in enrichment 
+         analysis.",
+        id = "filter_warning",
+        duration = 20,
+        type = "warning",
+        session = session
+      )
+    })
+    
+    observe({
+      req(!tab() %in% c("Clustering", "Load Data", 
+                        "Network", "Bicluster", 
+                        "DEG2"))
+      removeNotification(id = "filter_warning",
+                         session = session)
+    })
 
     # Counts barplot ------------
     raw_counts <- reactive({
@@ -1330,6 +1351,7 @@ mod_02_pre_process_server <- function(id, load_data, tab) {
       raw_counts = reactive(processed_data()$raw_counts),
       data = reactive(processed_data()$data),
       p_vals = reactive(processed_data()$p_vals),
+      filter_size = reactive(processed_data()$data_size[3]),
       sample_info = reactive(load_data$sample_info()),
       all_gene_names = reactive(load_data$all_gene_names()),
       gmt_choices = reactive(load_data$gmt_choices()),

--- a/R/mod_03_clustering.R
+++ b/R/mod_03_clustering.R
@@ -902,6 +902,9 @@ mod_03_clustering_server <- function(id, pre_process, load_data, idep_data, tab)
       processed_data = reactive({
         pre_process$data()
       }),
+      filter_size = reactive({
+        pre_process$filter_size()
+      }),
       gene_info = reactive({
         pre_process$all_gene_info()
       }),

--- a/R/mod_05_deg.R
+++ b/R/mod_05_deg.R
@@ -1298,6 +1298,9 @@ mod_05_deg_server <- function(id, pre_process, idep_data, load_data, tab) {
       processed_data = reactive({
         pre_process$data()
       }),
+      filter_size = reactive({
+        pre_process$filter_size()
+      }),
       gene_info = reactive({
         pre_process$all_gene_info()
       }),

--- a/R/mod_08_bicluster.R
+++ b/R/mod_08_bicluster.R
@@ -217,6 +217,9 @@ mod_08_bicluster_server <- function(id, pre_process, idep_data, tab) {
       processed_data = reactive({
         pre_process$data()
       }),
+      filter_size = reactive({
+        pre_process$filter_size()
+      }),
       gene_info = reactive({
         pre_process$all_gene_info()
       }),

--- a/R/mod_09_network.R
+++ b/R/mod_09_network.R
@@ -389,6 +389,9 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
       processed_data = reactive({
         pre_process$data()
       }),
+      filter_size = reactive({
+        pre_process$filter_size()
+      }),
       gene_info = reactive({
         pre_process$all_gene_info()
       }),

--- a/R/mod_11_enrichment.R
+++ b/R/mod_11_enrichment.R
@@ -345,6 +345,7 @@ mod_11_enrichment_server <- function(id,
                                      gmt_choices, # list of pathway categories "GOBP"
                                      gene_lists, # list of genes, each element is a list
                                      processed_data,
+                                     filter_size,
                                      gene_info,
                                      idep_data,
                                      select_org,
@@ -389,6 +390,26 @@ mod_11_enrichment_server <- function(id,
         inputId = ns("select_cluster"),
         selected = selected
       )
+    })
+    
+    observe({
+      req(!is.null(filter_size()))
+      
+      if(filter_size() < 1000) {
+        
+        updateCheckboxInput(
+          session = session,
+          inputId = "filtered_background",
+          value = FALSE
+        )
+      } else {
+        updateCheckboxInput(
+          session = session,
+          inputId = "filtered_background",
+          value = TRUE
+        )
+      }
+      
     })
 
     output$select_cluster <- renderUI({


### PR DESCRIPTION
## Issue #671 :
* Pre-process module now passes the number of filtered genes to any tab that uses the Enrichment module
* If there are below 1000 filtered genes, the filtered genes will not be used as the default background for enrichment analysis
  * All genes used instead
* Message displayed to user by the Pre-processing tab when this occurs