### PR TITLE
Global Settings Color Change

### DIFF
--- a/R/mod_01_load_data.R
+++ b/R/mod_01_load_data.R
@@ -153,7 +153,8 @@ mod_01_load_data_ui <- function(id) {
         br(),
         checkboxInput(
           inputId = ns("customize_button"),
-          label = strong("Global Settings"),
+          label = strong("Global Settings",
+                         style = "color: red;"),
           value = FALSE
         ),
         selectInput(


### PR DESCRIPTION
## Issue #548 :
* Instead of expanding all options, which would congest the page, we can make the global options stand out in other ways
* Changed "Global Settings" checkbox text to red, to increase noticeability