### PR TITLE
Tree & Network Plot Colors

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -49,6 +49,7 @@ app_server <- function(input, output, session) {
   mod_03_clustering_server(
     id = "clustering",
     pre_process = pre_process,
+    load_data = load_data,
     idep_data = idep_data,
     tab = tab
   )

--- a/R/fct_11_enrichment.R
+++ b/R/fct_11_enrichment.R
@@ -323,6 +323,7 @@ enrich_barplot <- function(enrichment_dataframe,
 #' @param wrap_text_network_deg Wrap the text from the pathway description
 #' @param layout_vis_deg Button to reset the layout of the network
 #' @param edge_cutoff_deg P-value to cutoff enriched pathways
+#' @param group_color 
 #'
 #' @export
 #' @return Data that can be inputted in the vis_network_plot function
@@ -331,7 +332,8 @@ network_data <- function(network,
                          up_down_reg_deg,
                          wrap_text_network_deg,
                          layout_vis_deg,
-                         edge_cutoff_deg) {
+                         edge_cutoff_deg,
+                         group_color) {
   if (up_down_reg_deg != "All Groups") {
     network <- network[network$Direction == up_down_reg_deg, ]
   }
@@ -347,7 +349,8 @@ network_data <- function(network,
   g <- enrichment_network(
     network,
     layout_button = layout_vis_deg,
-    edge_cutoff = edge_cutoff_deg
+    edge_cutoff = edge_cutoff_deg,
+    group_color = group_color
   )
 
   if (is.null(g)) {
@@ -369,7 +372,8 @@ network_data <- function(network,
 #' ENRICHMENT NETWORK FUNCTION
 enrichment_network <- function(go_table,
                                layout_button = 0,
-                               edge_cutoff = 5) {
+                               edge_cutoff = 5,
+                               group_color) {
   req(!is.null(go_table))
   gene_lists <- lapply(go_table$Genes, function(x) unlist(strsplit(as.character(x), " ")))
   names(gene_lists) <- go_table$Pathways
@@ -384,7 +388,7 @@ enrichment_network <- function(go_table,
     degree_cutoff = 0,
     n = 200,
     group = go_table$Direction,
-    group_color = gg_color_hue(2 + length(unique(go_table$Direction))),
+    group_color = group_color,
     vertex.label.cex = 1,
     vertex.label.color = "black",
     show_legend = FALSE,

--- a/R/mod_01_load_data.R
+++ b/R/mod_01_load_data.R
@@ -179,7 +179,7 @@ mod_01_load_data_ui <- function(id) {
         ),
         selectInput(
           inputId = ns("plots_color_select"),
-          label = "Plots Color scheme:",
+          label = "Plots Color scheme (PCA/Pre-Process):",
           choices = c(
             "Set1",
             "Set2",
@@ -196,7 +196,7 @@ mod_01_load_data_ui <- function(id) {
         ),
         selectInput(
           inputId = ns("heatmap_color_select"),
-          label = "Heatmap Color scheme:",
+          label = "Heatmap/Tree/Network Color scheme:",
           choices = c(
             "Green-Black-Red",
             "Red-Black-Green",

--- a/R/mod_03_clustering.R
+++ b/R/mod_03_clustering.R
@@ -890,7 +890,7 @@ mod_03_clustering_server <- function(id, pre_process, load_data, idep_data, tab)
         write.csv(heatmap_data_download(), file)
       }
     )
-
+    
     enrichment_table_cluster <- mod_11_enrichment_server(
       id = "enrichment_table_cluster",
       gmt_choices = reactive({
@@ -920,6 +920,9 @@ mod_03_clustering_server <- function(id, pre_process, load_data, idep_data, tab)
       }),
       ggplot2_theme = reactive({
         pre_process$ggplot2_theme()
+      }),
+      heat_colors = reactive({
+        strsplit(load_data$heatmap_color_select(), "-")[[1]][c(1,3)]
       })
     )
 

--- a/R/mod_05_deg.R
+++ b/R/mod_05_deg.R
@@ -1316,6 +1316,9 @@ mod_05_deg_server <- function(id, pre_process, idep_data, load_data, tab) {
       }),
       ggplot2_theme = reactive({
         pre_process$ggplot2_theme()
+      }),
+      heat_colors = reactive({
+        strsplit(load_data$heatmap_color_select(), "-")[[1]][c(1,3)]
       })
     )
 

--- a/R/mod_06_pathway.R
+++ b/R/mod_06_pathway.R
@@ -208,11 +208,6 @@ mod_06_pathway_ui <- function(id) {
           tabPanel(
             title = "Tree",
             br(),
-            selectInput(
-              inputId = ns("leaf_colors"),
-              label = "Select leaf colors (low-high)",
-              choices = "green-red"
-            ),
             plotOutput(
               outputId = ns("enrichment_tree"),
               width = "100%"
@@ -1386,14 +1381,6 @@ mod_06_pathway_server <- function(id, pre_process, deg, idep_data, tab) {
         show_pathway_id = show_pathway_id
       )
     })
-    
-    observe({
-      updateSelectInput(
-        session = session,
-        inputId = "leaf_colors",
-        choices = kegg_choices
-      )
-    })
 
     enrichment_tree_p <- reactive({
       req(!is.null(pathway_list_data()))
@@ -1401,7 +1388,8 @@ mod_06_pathway_server <- function(id, pre_process, deg, idep_data, tab) {
         go_table = pathway_list_data(),
         group = "All Groups",
         right_margin = 30,
-        leaf_color_choices = kegg_colors[[input$leaf_colors]]
+        leaf_color_choices = strsplit(pre_process$heatmap_color_select(), 
+                                      "-")[[1]][c(1,3)]
       )
       p <- recordPlot()
       return(p)
@@ -1428,7 +1416,9 @@ mod_06_pathway_server <- function(id, pre_process, deg, idep_data, tab) {
         up_down_reg_deg = input$up_down_reg_deg,
         wrap_text_network_deg = input$wrap_text_network_deg,
         layout_vis_deg = input$layout_vis_deg,
-        edge_cutoff_deg = input$edge_cutoff_deg
+        edge_cutoff_deg = input$edge_cutoff_deg,
+        group_color = strsplit(pre_process$heatmap_color_select(), 
+                               "-")[[1]][c(1,3)]
       )
     })
 

--- a/R/mod_08_bicluster.R
+++ b/R/mod_08_bicluster.R
@@ -235,6 +235,9 @@ mod_08_bicluster_server <- function(id, pre_process, idep_data, tab) {
       }),
       ggplot2_theme = reactive({
         pre_process$ggplot2_theme()
+      }),
+      heat_colors = reactive({
+        strsplit(pre_process$heatmap_color_select(), "-")[[1]][c(1,3)]
       })
     )
 

--- a/R/mod_09_network.R
+++ b/R/mod_09_network.R
@@ -407,6 +407,9 @@ mod_09_network_server <- function(id, pre_process, idep_data, tab) {
       }),
       ggplot2_theme = reactive({
         pre_process$ggplot2_theme()
+      }),
+      heat_colors = reactive({
+        strsplit(pre_process$heatmap_color_select(), "-")[[1]][c(1,3)]
       })
     )
 

--- a/R/mod_11_enrichment.R
+++ b/R/mod_11_enrichment.R
@@ -351,7 +351,8 @@ mod_11_enrichment_server <- function(id,
                                      converted,
                                      gmt_file,
                                      plot_grid_lines,
-                                     ggplot2_theme) {
+                                     ggplot2_theme,
+                                     heat_colors) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     observe({
@@ -708,7 +709,8 @@ mod_11_enrichment_server <- function(id,
       enrichment_tree_plot(
         go_table = enrichment_dataframe_for_tree(),
         group = input$select_cluster,
-        right_margin = 30
+        right_margin = 30,
+        leaf_color_choices = heat_colors()
       )
     })
 
@@ -739,7 +741,8 @@ mod_11_enrichment_server <- function(id,
         up_down_reg_deg = input$select_cluster,
         wrap_text_network_deg = input$wrap_text_network_deg,
         layout_vis_deg = input$layout_vis_deg,
-        edge_cutoff_deg = input$edge_cutoff_deg
+        edge_cutoff_deg = input$edge_cutoff_deg,
+        group_color = heat_colors()
       )
     })
 

--- a/man/enrichment_network.Rd
+++ b/man/enrichment_network.Rd
@@ -4,7 +4,7 @@
 \alias{enrichment_network}
 \title{ENRICHMENT NETWORK FUNCTION}
 \usage{
-enrichment_network(go_table, layout_button = 0, edge_cutoff = 5)
+enrichment_network(go_table, layout_button = 0, edge_cutoff = 5, group_color)
 }
 \description{
 ENRICHMENT NETWORK FUNCTION

--- a/man/network_data.Rd
+++ b/man/network_data.Rd
@@ -9,7 +9,8 @@ network_data(
   up_down_reg_deg,
   wrap_text_network_deg,
   layout_vis_deg,
-  edge_cutoff_deg
+  edge_cutoff_deg,
+  group_color
 )
 }
 \arguments{
@@ -22,6 +23,8 @@ network_data(
 \item{layout_vis_deg}{Button to reset the layout of the network}
 
 \item{edge_cutoff_deg}{P-value to cutoff enriched pathways}
+
+\item{group_color}{}
 }
 \value{
 Data that can be inputted in the vis_network_plot function


### PR DESCRIPTION
## Issue #568 :
* Changed colors of Tree and Network plots in the Enrichment and Pathway modules
  * Colors now match first and last colors of the global setting for the heatmap color scheme
  * Needed to pass global setting to all tabs that use the Enrichment module
* Removed leaf color selection in Pathway/Tree tab
* Changed labels for color scheme selection in global settings to make them more descriptive for users