### PR TITLE
Add TPM download to pre-process module; addresses #63

### DIFF
--- a/R/fct_02_pre_process.R
+++ b/R/fct_02_pre_process.R
@@ -1976,3 +1976,51 @@ generate_colors <- function(n, palette_name = "Set1") {
   }
 }
 
+
+#' Compute Transcripts Per Million (TPM) from a counts matrix.
+#'
+#' Pure function. Genes with missing or non-positive lengths are dropped, and
+#' genes present in only one of the inputs are dropped. Library-size scaling
+#' is applied per sample (column).
+#'
+#' @param counts Numeric matrix with genes in rows and samples in columns.
+#'   Row names must be gene identifiers matching \code{names(gene_lengths)}.
+#' @param gene_lengths Named numeric vector of per-gene transcript lengths in
+#'   base pairs.
+#'
+#' @export
+#' @return A list with two elements:
+#' \describe{
+#'   \item{tpm}{Numeric matrix of TPM values, same orientation as \code{counts}.
+#'     Column sums equal 1e6 (within floating-point tolerance) for any sample
+#'     in which at least one surviving gene has non-zero counts. Samples
+#'     where every surviving gene has zero counts produce a column of zeros.}
+#'   \item{n_dropped}{Integer count of input rows excluded due to missing or
+#'     non-positive lengths or no length match.}
+#' }
+compute_tpm <- function(counts, gene_lengths) {
+  if (is.null(counts) || nrow(counts) == 0 || ncol(counts) == 0) {
+    return(list(tpm = counts, n_dropped = 0L))
+  }
+
+  shared <- intersect(rownames(counts), names(gene_lengths))
+  lengths <- gene_lengths[shared]
+  valid <- !is.na(lengths) & lengths > 0
+  shared <- shared[valid]
+  lengths <- lengths[valid]
+
+  n_dropped <- nrow(counts) - length(shared)
+
+  if (length(shared) == 0) {
+    empty <- counts[integer(0), , drop = FALSE]
+    return(list(tpm = empty, n_dropped = n_dropped))
+  }
+
+  counts_sub <- counts[shared, , drop = FALSE]
+  rpk <- counts_sub / (lengths / 1000)
+  scaling <- colSums(rpk)
+  scaling[scaling == 0] <- 1  # avoid division by zero in empty samples
+  tpm <- t(t(rpk) / scaling) * 1e6
+
+  list(tpm = tpm, n_dropped = as.integer(n_dropped))
+}

--- a/R/fct_database.R
+++ b/R/fct_database.R
@@ -1010,3 +1010,53 @@ pathway_source_info <- function(pathway_file, go, select_org, idep_data) {
     return(pathway_info)
   }
 }
+
+
+#' Look up gene transcript lengths from the species database.
+#'
+#' Queries the geneInfo table for transcript_length values keyed by
+#' ensembl_gene_id. Used by the TPM download in the pre-process module.
+#'
+#' @param ensembl_ids Character vector of Ensembl gene IDs.
+#' @param select_org String designating the species (e.g., the value of
+#'   input$select_org from the load-data module).
+#' @param idep_data Data object returned by \code{\link{get_idep_data}()}.
+#'
+#' @export
+#' @return Named numeric vector of transcript lengths in base pairs, named by
+#'   ensembl_gene_id. Returns \code{NULL} if the DB connection fails or the
+#'   species has no geneInfo table.
+get_gene_lengths <- function(ensembl_ids, select_org, idep_data) {
+  if (length(ensembl_ids) == 0) {
+    return(NULL)
+  }
+
+  conn_db <- connect_convert_db_org(
+    select_org = select_org,
+    idep_data = idep_data
+  )
+  if (is.null(conn_db) || inherits(conn_db, "try-error")) {
+    return(NULL)
+  }
+  on.exit(DBI::dbDisconnect(conn_db), add = TRUE)
+
+  if (!"geneInfo" %in% DBI::dbListTables(conn_db)) {
+    return(NULL)
+  }
+
+  ids <- gsub("\"|\'", "", ensembl_ids)
+  query <- paste0(
+    "SELECT ensembl_gene_id, transcript_length FROM geneInfo ",
+    "WHERE ensembl_gene_id IN ('",
+    paste(ids, collapse = "', '"),
+    "')"
+  )
+  result <- DBI::dbGetQuery(conn_db, query)
+  if (nrow(result) == 0) {
+    return(NULL)
+  }
+
+  lengths <- as.numeric(result$transcript_length)
+  names(lengths) <- result$ensembl_gene_id
+  lengths
+}

--- a/R/mod_02_pre_process.R
+++ b/R/mod_02_pre_process.R
@@ -227,7 +227,7 @@ mod_02_pre_process_ui <- function(id) {
         ),
         fluidRow(
           column(
-            width = 6,
+            width = 4,
             downloadButton(
               outputId = ns("download_processed_data"),
               label = "Processed data"
@@ -239,12 +239,9 @@ mod_02_pre_process_ui <- function(id) {
             )
           ),
           column(
-            width = 6,
-            # Conditional panel for read count data ------------
+            width = 4,
             conditionalPanel(
               condition = "output.data_file_format == 1",
-
-              # Download the counts data with converted IDs
               downloadButton(
                 outputId = ns("download_converted_counts"),
                 label = "Converted counts"
@@ -252,6 +249,27 @@ mod_02_pre_process_ui <- function(id) {
               tippy::tippy_this(
                 ns("download_converted_counts"),
                 "Download counts with gene IDs converted to Ensembl.",
+                theme = "light"
+              ),
+              ns = ns
+            )
+          ),
+          column(
+            width = 4,
+            conditionalPanel(
+              condition = "output.data_file_format == 1 && output.select_org != 'NEW'",
+              downloadButton(
+                outputId = ns("download_tpm"),
+                label = "TPM"
+              ),
+              tippy::tippy_this(
+                ns("download_tpm"),
+                paste(
+                  "Download TPM (Transcripts Per Million) computed from",
+                  "raw counts and Ensembl transcript lengths. Note: TPM",
+                  "values will not exactly match upstream effective TPM ",
+                  "lengths."
+                ),
                 theme = "light"
               ),
               ns = ns
@@ -1488,6 +1506,34 @@ mod_02_pre_process_server <- function(id, load_data, tab) {
       )
     })
 
+    # TPM is only meaningful for raw read counts (data_file_format == 1).
+    tpm_result <- reactive({
+      req(load_data$data_file_format() == 1)
+      req(!is.null(processed_data()$raw_counts))
+
+      counts <- processed_data()$raw_counts
+      gene_lengths <- get_gene_lengths(
+        ensembl_ids = rownames(counts),
+        select_org = load_data$select_org(),
+        idep_data = idep_data
+      )
+      if (is.null(gene_lengths)) {
+        return(NULL)
+      }
+      compute_tpm(counts, gene_lengths)
+    })
+
+    merged_tpm_data <- reactive({
+      result <- tpm_result()
+      req(!is.null(result))
+
+      merge_data(
+        load_data$all_gene_names(),
+        result$tpm,
+        merge_ID = "ensembl_ID"
+      )
+    })
+
     # Pre-Process Data Table ----------
     output$examine_data <- DT::renderDataTable({
       req(!is.null(merged_processed_data()))
@@ -1713,6 +1759,45 @@ mod_02_pre_process_server <- function(id, load_data, tab) {
       },
       content = function(file) {
         write.csv(merged_raw_counts_data(), file, row.names = FALSE)
+      }
+    )
+    output$download_tpm <- downloadHandler(
+      filename = function() {
+        "tpm_data.csv"
+      },
+      content = function(file) {
+        result <- tpm_result()
+        if (is.null(result)) {
+          showNotification(
+            paste(
+              "TPM cannot be computed: no transcript-length data available",
+              "for the selected species."
+            ),
+            type = "error",
+            duration = 8
+          )
+          writeLines(
+            paste(
+              "TPM could not be computed for this dataset: no transcript-",
+              "length data is available for the selected species.",
+              "TPM is supported for read-counts data when an iDEP-supported",
+              "species is selected."
+            ),
+            con = file
+          )
+          return(invisible())
+        }
+        if (result$n_dropped > 0) {
+          showNotification(
+            paste0(
+              result$n_dropped,
+              " gene(s) excluded from TPM due to missing transcript lengths."
+            ),
+            type = "warning",
+            duration = 8
+          )
+        }
+        write.csv(merged_tpm_data(), file, row.names = FALSE)
       }
     )
 

--- a/tests/testthat/test-tpm.R
+++ b/tests/testthat/test-tpm.R
@@ -1,0 +1,83 @@
+test_that("compute_tpm produces column sums of 1e6", {
+  counts <- matrix(
+    c(10, 20,
+      40, 80,
+      0,  100),
+    nrow = 3, byrow = TRUE,
+    dimnames = list(c("g1", "g2", "g3"), c("s1", "s2"))
+  )
+  lengths <- c(g1 = 1000, g2 = 2000, g3 = 500)
+
+  result <- compute_tpm(counts, lengths)
+
+  expect_equal(unname(colSums(result$tpm)), c(1e6, 1e6))
+  expect_equal(result$n_dropped, 0L)
+  expect_equal(rownames(result$tpm), c("g1", "g2", "g3"))
+})
+
+test_that("compute_tpm matches a hand-computed example", {
+  # Two genes, equal counts of 100 in one sample.
+  # g1 length 1 kb, g2 length 4 kb.
+  # rpk = c(100, 25); scaling = 125; tpm = c(800000, 200000).
+  counts <- matrix(
+    c(100, 100),
+    nrow = 2,
+    dimnames = list(c("g1", "g2"), "s1")
+  )
+  lengths <- c(g1 = 1000, g2 = 4000)
+
+  result <- compute_tpm(counts, lengths)
+
+  expect_equal(unname(result$tpm[, 1]), c(800000, 200000))
+})
+
+test_that("compute_tpm drops genes with NA or zero length", {
+  counts <- matrix(
+    c(10, 20, 30, 40),
+    nrow = 4, ncol = 1,
+    dimnames = list(c("g1", "g2", "g3", "g4"), "s1")
+  )
+  lengths <- c(g1 = 1000, g2 = NA_real_, g3 = 0, g4 = 2000)
+
+  result <- compute_tpm(counts, lengths)
+
+  expect_equal(rownames(result$tpm), c("g1", "g4"))
+  expect_equal(result$n_dropped, 2L)
+  expect_equal(unname(colSums(result$tpm)), 1e6)
+})
+
+test_that("compute_tpm drops genes missing from lengths vector", {
+  counts <- matrix(
+    c(10, 20, 30),
+    nrow = 3, ncol = 1,
+    dimnames = list(c("g1", "g2", "g3"), "s1")
+  )
+  lengths <- c(g1 = 1000, g3 = 500)
+
+  result <- compute_tpm(counts, lengths)
+
+  expect_equal(sort(rownames(result$tpm)), c("g1", "g3"))
+  expect_equal(result$n_dropped, 1L)
+})
+
+test_that("compute_tpm handles no overlap without crashing", {
+  counts <- matrix(
+    c(10, 20),
+    nrow = 2, ncol = 1,
+    dimnames = list(c("g1", "g2"), "s1")
+  )
+  lengths <- c(other_gene = 1000)
+
+  result <- compute_tpm(counts, lengths)
+
+  expect_equal(nrow(result$tpm), 0L)
+  expect_equal(result$n_dropped, 2L)
+})
+
+test_that("compute_tpm handles empty counts matrix", {
+  counts <- matrix(numeric(0), nrow = 0, ncol = 0)
+  result <- compute_tpm(counts, c(g1 = 1000))
+
+  expect_equal(nrow(result$tpm), 0L)
+  expect_equal(result$n_dropped, 0L)
+})


### PR DESCRIPTION
TPM download is enabled for read-counts data when an iDEP-supported species is selected. Not available for custom (NEW) species, since transcript-length data is sourced from the species DB.

Button location:

<img width="995" height="636" alt="image" src="https://github.com/user-attachments/assets/4f23c56e-b54e-4213-88e5-512b9f437561" />