### PR TITLE
Refine interactive experiment design wizard

### DIFF
--- a/R/fct_01_load_data.R
+++ b/R/fct_01_load_data.R
@@ -145,6 +145,35 @@ sanitize_names <- function(values) {
   values
 }
 
+#' Strict sanitizer for labels created in the design-builder wizard
+#'
+#' Keeps only ASCII alphanumerics and underscore \u2014 strips all other
+#' punctuation, whitespace, control characters, and non-ASCII (accented Latin,
+#' CJK, emoji). Underscore is preserved so that sample-name patterns like
+#' "WT_Rep1" still parse correctly in [detect_groups()].
+#'
+#' Use this for labels the user typed in the GUI wizard (factor names, level
+#' names, cell values), where we want a clean canonical form. For uploaded
+#' files use [sanitize_names()] to preserve more of the original text.
+#'
+#' @param values Character vector to clean.
+#' @return Cleaned character vector containing only \[A-Za-z0-9_\].
+#' @export
+sanitize_created_names <- function(values) {
+  if (is.null(values)) {
+    return(values)
+  }
+
+  na_mask <- is.na(values)
+  if (!is.character(values)) {
+    values <- as.character(values)
+  }
+
+  values <- gsub("[^A-Za-z0-9_]", "", values, perl = TRUE)
+  values[na_mask] <- NA_character_
+  values
+}
+
 clean_design_table <- function(tbl) {
   if (is.null(tbl)) {
     return(tbl)
@@ -1009,12 +1038,13 @@ showGeneIDs <- function(species, db, nGenes = 10){
 #   FROM TempExampleIds AS t
 #   WHERE t.id = i.id
 # );
-#
+# 
 # -- Drop the temporary table
 # DROP  TABLE TempExampleIds;
-#
+# 
 # -- View results
 # SELECT * FROM idIndex
+
 
 #' Create a design file template data frame from sample names
 #'
@@ -1053,7 +1083,7 @@ build_sample_info_from_df <- function(design_df, sample_names,
     return(NULL)
   }
 
-  rownames(design_df) <- sanitize_names(rownames(design_df))
+  rownames(design_df) <- sanitize_created_names(rownames(design_df))
 
   # Drop rows with empty factor names
   valid_rows <- nchar(rownames(design_df)) > 0
@@ -1062,7 +1092,7 @@ build_sample_info_from_df <- function(design_df, sample_names,
 
   # Sanitize, uppercase, and truncate all cell values
   for (i in seq_len(nrow(design_df))) {
-    design_df[i, ] <- toupper(sanitize_names(as.character(design_df[i, ])))
+    design_df[i, ] <- toupper(sanitize_created_names(as.character(design_df[i, ])))
     design_df[i, ] <- truncate_labels_safely(
       as.character(design_df[i, ]), max_group_name_length
     )
@@ -1088,5 +1118,57 @@ build_sample_info_from_df <- function(design_df, sample_names,
   t(as.matrix(design_df))
 }
 
+#' Find pairs of near-duplicate strings (case-insensitive)
+#'
+#' Catches likely typos in user-entered labels (e.g. "CTRL" vs "CTR"). Returns
+#' formatted pair strings for use in user notifications. NA, empty, and exact
+#' duplicates are removed before comparison.
+#'
+#' @param values Character vector of labels.
+#' @param max_dist Maximum Levenshtein distance to flag (default 1).
+#' @return Character vector of pair labels like "'CTRL' ↔ 'CTR'"; empty if none.
+#' @export
+near_duplicate_pairs <- function(values, max_dist = 1L) {
+  v <- as.character(values)
+  v <- v[!is.na(v) & nchar(v) > 0L]
+  v <- unique(v)
+  if (length(v) < 2L) return(character(0))
 
+  d <- as.matrix(utils::adist(v, ignore.case = TRUE))
+  hits <- which(d > 0L & d <= max_dist & upper.tri(d), arr.ind = TRUE)
+  if (nrow(hits) == 0L) return(character(0))
 
+  # Suppress likely-intentional patterns that look like typos by edit distance:
+  #   - Very short labels (max length <= 2): distance 1 = half the string,
+  #     too noisy to flag reliably (e.g. "WT" vs "KO").
+  #   - Numbered series: stripping trailing digits leaves the same root
+  #     (e.g. "S1"/"S2", "Rep1"/"Rep10", "1"/"2").
+  keep <- vapply(seq_len(nrow(hits)), function(k) {
+    a <- v[hits[k, 1L]]
+    b <- v[hits[k, 2L]]
+    if (max(nchar(a), nchar(b)) <= 2L) return(FALSE)
+    if (sub("[0-9]+$", "", a) == sub("[0-9]+$", "", b)) return(FALSE)
+    TRUE
+  }, logical(1L))
+  hits <- hits[keep, , drop = FALSE]
+  if (nrow(hits) == 0L) return(character(0))
+
+  sprintf("'%s' ↔ '%s'", v[hits[, 1L]], v[hits[, 2L]])
+}
+
+#' Detect any non-ASCII characters in user-entered labels
+#'
+#' Accented Latin, CJK, Cyrillic, emoji etc. survive sanitize_names() but may
+#' get rewritten downstream when limma/DESeq2 build contrast strings. Use this
+#' to warn the user before the design is applied.
+#'
+#' @param values Character vector.
+#' @return Single logical: TRUE if any element contains a non-ASCII codepoint.
+#' @export
+has_non_ascii <- function(values) {
+  if (is.null(values) || length(values) == 0L) return(FALSE)
+  v <- as.character(values)
+  v <- v[!is.na(v) & nchar(v) > 0L]
+  if (length(v) == 0L) return(FALSE)
+  any(grepl("[^\x01-\x7f]", v, perl = TRUE))
+}

--- a/R/mod_01_load_data.R
+++ b/R/mod_01_load_data.R
@@ -1259,8 +1259,7 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
         style = "margin-top: 4px;margin-bottom: 9px;",
         actionButton(
           inputId = ns("build_design_btn"),
-          label = "Or build design interactively",
-          icon = icon("table"),
+          label = "+ Create design",
           class = "btn-xs btn-default"
         ),
         if (!is.null(gui_design())) {
@@ -1306,7 +1305,7 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
               tags$small(
                 style = "color: #666; margin-top: 5px; display: block;",
                 shiny::icon("info-circle"),
-                " Pair indices (1, 2, 3 \u2026) will be assigned per sample in the next step."
+                " Pair indices assigned per sample in the next step."
               )
             )
           ),
@@ -1329,43 +1328,87 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
       req(!is.null(loaded_data()$data))
       sample_names <- colnames(loaded_data()$data)
 
-      n_guided_factors(2L)
-      guided_factor_defs(NULL)
-      initial_groups <- detect_groups(sample_names)
-      level_suggestion <- paste(unique(initial_groups), collapse = ", ")
+      # If a design was previously applied, pre-fill the wizard from it so the
+      # user can tweak a cell or download the CSV without rebuilding. Treat all
+      # factors as non-blocking — blocking metadata is not stored in the
+      # applied matrix.
+      applied_design <- gui_design()
+      has_applied <- !is.null(applied_design) && ncol(applied_design) > 0L
+
+      if (has_applied) {
+        applied_factor_defs <- lapply(seq_len(ncol(applied_design)), function(i) {
+          col_values <- as.character(applied_design[, i])
+          list(
+            name = colnames(applied_design)[i],
+            levels = unique(col_values),
+            is_blocking = FALSE
+          )
+        })
+        applied_assignments <- setNames(
+          lapply(seq_along(applied_factor_defs), function(i) {
+            as.character(applied_design[, i])
+          }),
+          as.character(seq_along(applied_factor_defs))
+        )
+        n_guided_factors(length(applied_factor_defs))
+        guided_factor_defs(applied_factor_defs)
+        sample_assignments(applied_assignments)
+
+        factor_rows_init <- lapply(
+          seq_along(applied_factor_defs),
+          function(i) {
+            make_guided_factor_row(
+              i,
+              default_name = applied_factor_defs[[i]]$name,
+              default_levels = paste(
+                applied_factor_defs[[i]]$levels,
+                collapse = ", "
+              )
+            )
+          }
+        )
+      } else {
+        n_guided_factors(2L)
+        guided_factor_defs(NULL)
+        sample_assignments(list())
+        initial_groups <- detect_groups(sample_names)
+        level_suggestion <- paste(unique(initial_groups), collapse = ", ")
+        factor_rows_init <- list(
+          make_guided_factor_row(1L, "group", level_suggestion),
+          make_guided_factor_row(2L)
+        )
+      }
 
       shiny::showModal(shiny::modalDialog(
-        title = "Build Experimental Design",
+        title = "Experiment Design",
         size = "l",
         tabsetPanel(
           id = ns("design_builder_tab"),
           tabPanel(
-            "Guided Builder",
+            "Guided",
             br(),
             # Step 1: define factors and levels
             div(
               id = ns("guided_step1"),
+              style = "overflow-x: hidden;",
               tags$p(
                 style = "color: #555; font-size: 13px; margin-bottom: 12px;",
-                "Step 1: Name each factor (e.g. Treatment, Genotype, Batch) and ",
-                "its levels. Check \u2018Paired / blocking\u2019 for pair/replicate index factors.",
-                "Up to 5 factors."
+                "Name each factor and its levels. Up to 5 factors can be defined. Check 'Paired/blocking' for pair/replicate index factors."
               ),
               div(
                 id = ns("guided_factor_rows_container"),
-                make_guided_factor_row(1L, "group", level_suggestion),
-                make_guided_factor_row(2L)
+                factor_rows_init
               ),
               hr(),
               fluidRow(
                 column(
                   6,
                   actionButton(
-                    ns("add_guided_factor"), "+ Add another factor",
+                    ns("add_guided_factor"), "+ Factor",
                     class = "btn-xs btn-default"
                   ),
                   actionButton(
-                    ns("remove_guided_factor"), "- Remove last factor",
+                    ns("remove_guided_factor"), "- Factor",
                     class = "btn-xs btn-default",
                     style = "margin-left: 6px;"
                   )
@@ -1373,7 +1416,7 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
                 column(
                   6, align = "right",
                   actionButton(
-                    ns("guided_next_btn"), "Next: Assign samples \u2192",
+                    ns("guided_next_btn"), "Next \u2192",
                     class = "btn-primary btn-sm"
                   )
                 )
@@ -1383,28 +1426,21 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
             shinyjs::hidden(
               div(
                 id = ns("guided_step2"),
-                style = "max-height: 60vh; overflow-y: auto;",
+                style = "max-height: 60vh; overflow-y: auto; overflow-x: hidden;",
                 uiOutput(ns("guided_step2_ui")),
                 hr(),
                 fluidRow(
                   column(
-                    4,
+                    6,
                     actionButton(
-                      ns("guided_back_btn"), "← Back to factors",
+                      ns("guided_back_btn"), "← Back",
                       class = "btn-default btn-sm"
                     )
                   ),
                   column(
-                    4, align = "center",
-                    downloadButton(
-                      ns("download_guided_design"), "Download CSV",
-                      class = "btn-sm btn-default"
-                    )
-                  ),
-                  column(
-                    4, align = "right",
+                    6, align = "right",
                     actionButton(
-                      ns("apply_guided_design"), "Apply Design",
+                      ns("apply_guided_design"), "Apply",
                       class = "btn-primary btn-sm"
                     )
                   )
@@ -1413,39 +1449,47 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
             )
           ),
           tabPanel(
-            "Manual Fill-in",
+            "Manual",
             br(),
-            tags$p(
-              style = "color: #555; font-size: 13px; margin-bottom: 8px;",
-              "Each row is a factor; each column is a sample. Enter a factor name, ",
-              "then type a group label for each sample. Leave the factor name blank ",
-              "to skip a row. The first row is pre-filled from sample names."
+            fluidRow(
+              column(
+                9,
+                tags$p(
+                  style = "color: #555; font-size: 13px; margin-bottom: 8px;",
+                  "Rows are factors, columns are samples. Type a label per cell. Use consistent labels within each row. Row 1 is automatically filled based on sample names, but can be edited."
+                )
+              ),
+              column(
+                3, align = "right",
+
+                tags$div(
+                  id = ns("download_design_template_tip"),
+                  style = "display: inline-block;",
+                  downloadButton(
+                    ns("download_design_template"), " ",
+                    class = "btn-sm btn-default"
+                  )
+                ),
+
+                tippy::tippy_this(
+                  ns("download_design_template_tip"),
+                  "Download CSV",
+                  theme = "light-border",
+                  placement = "top"
+                )
+              )
             ),
             tags$style(HTML(
               ".design-grid-table .form-group { margin-bottom: 2px; }
                .design-grid-table input.form-control { font-size: 12px; padding: 2px 4px; height: 26px; }"
             )),
             div(style = "overflow-x: auto;", uiOutput(ns("design_grid_ui"))),
-            tags$small(
-              style = "color: #888; display: block; margin-top: 4px;",
-              shiny::icon("info-circle"),
-              " Labels will be converted to uppercase and spaces removed on apply."
-            ),
             hr(),
-            fluidRow(
-              column(
-                6,
-                downloadButton(
-                  ns("download_design_template"), "Download CSV",
-                  class = "btn-sm btn-default"
-                )
-              ),
-              column(
-                6, align = "right",
-                shiny::actionButton(
-                  ns("apply_design"), "Apply Design",
-                  class = "btn-primary btn-sm"
-                )
+            div(
+              style = "text-align: right;",
+              shiny::actionButton(
+                ns("apply_design"), "Apply",
+                class = "btn-primary btn-sm"
               )
             )
           )
@@ -1467,6 +1511,13 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
          };",
         ns("")
       ))
+
+      # If a design is already applied, skip directly to step 2 so the user
+      # sees chips colored per the current assignments.
+      if (has_applied) {
+        shinyjs::hide("guided_step1")
+        shinyjs::show("guided_step2")
+      }
     })
 
     # Add a factor row to the guided builder ----
@@ -1516,11 +1567,15 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
       n <- n_guided_factors()
       factor_defs <- list()
       errors <- character(0)
+      typo_warnings <- character(0)
+      non_ascii_seen <- FALSE
 
       for (i in seq_len(n)) {
         fname_raw <- input[[paste0("gf_name_", i)]]
-        # Sanitize factor name: remove spaces/hyphens (matches build_sample_info_from_df)
-        fname <- sanitize_names(trimws(if (is.null(fname_raw)) "" else fname_raw))
+        # Strict sanitizer (matches build_sample_info_from_df): keep [A-Za-z0-9_]
+        fname <- sanitize_created_names(
+          trimws(if (is.null(fname_raw)) "" else fname_raw)
+        )
 
         is_blocking <- isTRUE(input[[paste0("gf_blocking_", i)]])
 
@@ -1537,8 +1592,8 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
           raw_levels_input <- input[[paste0("gf_levels_", i)]]
           raw_levels <- if (is.null(raw_levels_input)) "" else raw_levels_input
           levels_vec <- trimws(strsplit(raw_levels, ",", fixed = TRUE)[[1L]])
-          # Sanitize + uppercase level names (matches build_sample_info_from_df cell treatment)
-          levels_vec <- toupper(sanitize_names(levels_vec))
+          # Strict sanitizer (matches build_sample_info_from_df cell treatment)
+          levels_vec <- toupper(sanitize_created_names(levels_vec))
           levels_vec <- levels_vec[nchar(levels_vec) > 0L]
           # Deduplicate after sanitization (e.g. "ctrl" and "Ctrl" both become "CTRL")
           levels_vec <- unique(levels_vec)
@@ -1549,6 +1604,14 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
             ))
             next
           }
+          near_dups <- near_duplicate_pairs(levels_vec)
+          if (length(near_dups) > 0L) {
+            typo_warnings <- c(typo_warnings, paste0(
+              "Factor '", fname, "': possible typo — ",
+              paste(near_dups, collapse = ", ")
+            ))
+          }
+          if (has_non_ascii(c(fname, levels_vec))) non_ascii_seen <- TRUE
           factor_defs[[length(factor_defs) + 1L]] <- list(
             name = fname, levels = levels_vec, is_blocking = FALSE
           )
@@ -1568,6 +1631,19 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
           type = "warning", duration = 5L
         )
         return()
+      }
+
+      if (length(typo_warnings) > 0L) {
+        shiny::showNotification(
+          paste(typo_warnings, collapse = " | "),
+          type = "warning", duration = 7L
+        )
+      }
+      if (non_ascii_seen) {
+        shiny::showNotification(
+          "Non-ASCII characters detected — downstream tools may rewrite them.",
+          type = "warning", duration = 6L
+        )
       }
 
       guided_factor_defs(factor_defs)
@@ -1593,9 +1669,33 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
       sample_names <- colnames(loaded_data()$data)
 
       tagList(
-        tags$p(
-          style = 'color: #555; font-size: 13px; margin-bottom: 12px;',
-          'Step 2: Select a level on the left, then click sample names on the right to assign them.'
+        fluidRow(
+          column(
+            9,
+            tags$p(
+              style = 'color: #555; font-size: 13px; margin-bottom: 12px;',
+              'Pick a level, then click samples to assign.'
+            )
+          ),
+          column(
+            3, align = "right",
+
+            tags$div(
+              id = ns("download_guided_design_tip"),
+              style = "display: inline-block;",
+              downloadButton(
+                ns("download_guided_design"), " ",
+                class = "btn-sm btn-default"
+              )
+            ),
+
+            tippy::tippy_this(
+              ns("download_guided_design_tip"),
+              "Download CSV",
+              theme = "light-border",
+              placement = "top"
+            )
+          )
         ),
         lapply(seq_along(fdefs), function(fi) {
           fdef <- fdefs[[fi]]
@@ -1633,8 +1733,7 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
               ),
               tags$p(
                 style = 'font-size: 12px; color: #666; margin-bottom: 8px;',
-                'Assign a pair index to each sample.',
-                'Samples sharing the same index are paired.'
+                'Same index = same pair.'
               ),
               div(style = 'overflow-x: auto;', do.call(tagList, sample_inputs))
             )
@@ -1651,7 +1750,7 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
                   4,
                   tags$p(
                     style = 'font-size: 12px; color: #555; margin-bottom: 6px;',
-                    'Select active level, then click samples:'
+                    'Active level:'
                   ),
                   radioButtons(
                     ns(paste0('active_level_', fi)),
@@ -1685,9 +1784,7 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
                   8,
                   tags$p(
                     style = 'font-size: 12px; color: #555; margin-bottom: 4px;',
-                    paste0('Levels: ', paste(fdef$levels, collapse = ', '), '.'),
-                    tags$br(),
-                    'Click a chip to assign it to the selected level.'
+                    paste0('Levels: ', paste(fdef$levels, collapse = ', '))
                   ),
                   div(
                     style = paste0(
@@ -1783,7 +1880,10 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
       j     <- input$chip_clicked$sample
       level <- input$chip_clicked$level
       sample_names <- colnames(loaded_data()$data)
-      # Guard: JS index could be stale if data changed while modal was open
+      fdefs <- guided_factor_defs()
+      # Guard: JS indices could be stale if factors/data changed mid-interaction
+      if (!is.numeric(fi) || fi < 1L ||
+          is.null(fdefs) || fi > length(fdefs)) return()
       if (!is.numeric(j) || j < 1L || j > length(sample_names)) return()
       asgn  <- sample_assignments()
       key   <- as.character(fi)
@@ -1872,6 +1972,13 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
         )
       }
 
+      if (has_non_ascii(c(row_names, unlist(rows)))) {
+        shiny::showNotification(
+          'Non-ASCII characters detected \u2014 downstream tools may rewrite them.',
+          type = 'warning', duration = 6L
+        )
+      }
+
       design_df <- as.data.frame(
         do.call(rbind, rows),
         stringsAsFactors = FALSE
@@ -1941,9 +2048,11 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
       req(!is.null(loaded_data()$data))
       sample_names <- colnames(loaded_data()$data)
       n <- length(sample_names)
-      n_factors <- 3L
+      n_factors <- 5L
 
       initial_groups <- detect_groups(sample_names)
+      applied_design <- gui_design()
+      n_applied <- if (is.null(applied_design)) 0L else ncol(applied_design)
 
       cell_px <- max(70L, min(110L, as.integer(660L / n)))
       cell_style <- paste0("min-width: ", cell_px, "px; padding: 2px;")
@@ -1965,8 +2074,19 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
       )
 
       factor_rows <- lapply(seq_len(n_factors), function(i) {
-        default_name <- if (i == 1L) "group" else ""
-        default_cells <- if (i == 1L) initial_groups else rep("", n)
+        # Row defaults priority:
+        #   1. Pre-fill from applied design if this row is within it.
+        #   2. Otherwise row 1 gets detect_groups guess; rest are blank.
+        if (i <= n_applied) {
+          default_name <- colnames(applied_design)[i]
+          default_cells <- as.character(applied_design[, i])
+        } else if (is.null(applied_design) && i == 1L) {
+          default_name <- "group"
+          default_cells <- initial_groups
+        } else {
+          default_name <- ""
+          default_cells <- rep("", n)
+        }
 
         name_td <- tags$td(
           style = "vertical-align: middle; padding: 2px;",
@@ -2001,7 +2121,7 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
       req(!is.null(loaded_data()$data))
       sample_names <- colnames(loaded_data()$data)
       n <- length(sample_names)
-      n_factors <- 3L
+      n_factors <- 5L
 
       rows <- list()
       row_names <- character(0)
@@ -2033,6 +2153,37 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
           type = "warning", duration = 5
         )
         return()
+      }
+
+      # Block on near-duplicate cell labels within the same factor row.
+      # Compare on the sanitized form (what becomes the design label).
+      typo_errors <- character(0)
+      for (k in seq_along(rows)) {
+        sanitized <- toupper(sanitize_created_names(rows[[k]]))
+        near_dups <- near_duplicate_pairs(sanitized)
+        if (length(near_dups) > 0L) {
+          typo_errors <- c(typo_errors, paste0(
+            "Factor '", row_names[k], "': ",
+            paste(near_dups, collapse = ", ")
+          ))
+        }
+      }
+      if (length(typo_errors) > 0L) {
+        shiny::showNotification(
+          paste0(
+            "Possible typos — fix or confirm before applying: ",
+            paste(typo_errors, collapse = " | ")
+          ),
+          type = "error", duration = 10
+        )
+        return()
+      }
+
+      if (has_non_ascii(c(row_names, unlist(rows)))) {
+        shiny::showNotification(
+          "Non-ASCII characters detected — downstream tools may rewrite them.",
+          type = "warning", duration = 6
+        )
       }
 
       design_df <- as.data.frame(
@@ -2068,16 +2219,16 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
         req(!is.null(loaded_data()$data))
         sample_names <- colnames(loaded_data()$data)
         n <- length(sample_names)
-        n_factors <- 3L
+        n_factors <- 5L
         initial_groups <- detect_groups(sample_names)
 
         rows <- list()
         row_names <- character(0)
         for (i in seq_len(n_factors)) {
-          factor_name <- input[[paste0("factor_name_", i)]]
-          if (is.null(factor_name) || nchar(trimws(factor_name)) == 0L) {
-            factor_name <- if (i == 1L) "group" else paste0("factor", i)
-          }
+          factor_name_raw <- input[[paste0("factor_name_", i)]]
+          name_provided <- !is.null(factor_name_raw) &&
+            nchar(trimws(factor_name_raw)) > 0L
+
           cell_values <- vapply(seq_len(n), function(j) {
             v <- input[[paste0("cell_", i, "_", j)]]
             if (is.null(v)) {
@@ -2086,8 +2237,32 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
               v
             }
           }, character(1L))
-          rows[[i]] <- cell_values
+          cells_provided <- any(nchar(trimws(cell_values)) > 0L)
+
+          # Skip rows where the user has provided neither a name nor any cell;
+          # otherwise the download would carry "factor2", "factor3"... empties.
+          if (!name_provided && !cells_provided) next
+
+          factor_name <- if (name_provided) {
+            trimws(factor_name_raw)
+          } else if (i == 1L) {
+            "group"
+          } else {
+            paste0("factor", i)
+          }
+          rows[[length(rows) + 1L]] <- cell_values
           row_names <- c(row_names, factor_name)
+        }
+
+        if (length(rows) == 0L) {
+          # Empty grid: write a header-only template so the user gets a usable file.
+          df <- as.data.frame(
+            matrix("", nrow = 0L, ncol = n),
+            stringsAsFactors = FALSE
+          )
+          colnames(df) <- sample_names
+          write.csv(df, file)
+          return()
         }
 
         row_names <- make.unique(row_names)
@@ -2169,9 +2344,11 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
       )
     })
 
-    # Disables experiment_file input to prevent multiple uploads
+    # Disables experiment_file input to prevent multiple uploads;
+    # clears any GUI-built design so the uploaded file is the source of truth.
     observeEvent(input$experiment_file, {
       shinyjs::disable("experiment_file")
+      gui_design(NULL)
     })
 
     # Notification for data type selection (species is now always selected)
@@ -2375,8 +2552,12 @@ mod_01_load_data_server <- function(id, idep_data, tab) {
         demo_metadata_file = demo_data_file()[2],
         max_group_name_length = input$max_group_name_length
       )
-      # Inject GUI-built design when no experiment file is uploaded
-      if (!is.null(gui_design()) && is.null(input$experiment_file)) {
+      # Inject GUI-built design when no experiment file is uploaded.
+      # Skip if input_data returned NULL — assigning into a NULL base would
+      # silently create list(sample_info = ...) and drop $data, $raw_counts, etc.
+      if (!is.null(base) &&
+          !is.null(gui_design()) &&
+          is.null(input$experiment_file)) {
         base$sample_info <- gui_design()
       }
       base

--- a/tests/testthat/test-design_builder.R
+++ b/tests/testthat/test-design_builder.R
@@ -185,3 +185,147 @@ test_that("build_sample_info_from_df returns NULL for empty input", {
     data.frame(), c("s1", "s2")
   ))
 })
+
+# --- near_duplicate_pairs() ---------------------------------------------------
+
+test_that("near_duplicate_pairs flags distance-1 typos", {
+  result <- near_duplicate_pairs(c("CTRL", "CTR", "TREATED"))
+  expect_length(result, 1L)
+  expect_true(grepl("CTRL", result) && grepl("CTR", result))
+})
+
+test_that("near_duplicate_pairs ignores exact duplicates and distance >= 2", {
+  expect_length(near_duplicate_pairs(c("CTRL", "CTRL", "TREATED")), 0L)
+  expect_length(near_duplicate_pairs(c("CTRL", "DRUG", "TREATED")), 0L)
+})
+
+test_that("near_duplicate_pairs is case-insensitive", {
+  expect_length(near_duplicate_pairs(c("Ctrl", "ctr")), 1L)
+})
+
+test_that("near_duplicate_pairs handles edge inputs", {
+  expect_length(near_duplicate_pairs(character(0)), 0L)
+  expect_length(near_duplicate_pairs("ALONE"), 0L)
+  expect_length(near_duplicate_pairs(c(NA_character_, "")), 0L)
+  expect_length(near_duplicate_pairs(c("CTRL", NA_character_, "")), 0L)
+})
+
+test_that("near_duplicate_pairs honors max_dist argument", {
+  # "kitten" -> "kitin" has distance 2
+  expect_length(near_duplicate_pairs(c("kitten", "kitin"), max_dist = 1L), 0L)
+  expect_length(near_duplicate_pairs(c("kitten", "kitin"), max_dist = 2L), 1L)
+})
+
+test_that("near_duplicate_pairs reports multiple pair hits", {
+  # Distance-1 pairs: CTRL↔CTR, CTR↔TR, TRT↔TR
+  # CTR↔TR and TRT↔TR are suppressed because max(nchar) <= 3 is OK but
+  # actually max here is 3 which is > 2, so they're flagged. CTRL↔CTR has
+  # max length 4, no shared digit-suffix root → also flagged. All 3 kept.
+  result <- near_duplicate_pairs(c("CTRL", "CTR", "TRT", "TR"))
+  expect_length(result, 3L)
+})
+
+test_that("near_duplicate_pairs skips numbered-series patterns", {
+  # Common lab labeling — these are intentional, not typos.
+  expect_length(near_duplicate_pairs(c("S1", "S2", "S3")), 0L)
+  expect_length(near_duplicate_pairs(c("Rep1", "Rep2", "Rep3")), 0L)
+  expect_length(near_duplicate_pairs(c("Sample1", "Sample10")), 0L)
+  expect_length(near_duplicate_pairs(c("D1", "D2")), 0L)
+  # Pure pair indices.
+  expect_length(near_duplicate_pairs(c("1", "2", "3")), 0L)
+})
+
+test_that("near_duplicate_pairs skips very short labels (max length <= 2)", {
+  # Length-2 strings: distance 1 = 50% mismatch, far past typo signal.
+  expect_length(near_duplicate_pairs(c("WT", "KT")), 0L)
+  expect_length(near_duplicate_pairs(c("A", "B")), 0L)
+})
+
+test_that("near_duplicate_pairs still flags genuine typos in longer labels", {
+  expect_length(near_duplicate_pairs(c("CTRL", "CTR")), 1L)
+  expect_length(near_duplicate_pairs(c("treated", "treatd")), 1L)
+  # Different root, both length >= 3 → real typo signal.
+  expect_length(near_duplicate_pairs(c("Day1", "Bay1")), 1L)
+})
+
+# --- has_non_ascii() ----------------------------------------------------------
+
+test_that("has_non_ascii returns FALSE for pure-ASCII input", {
+  expect_false(has_non_ascii(c("CTRL", "TREATED", "WT_REP1")))
+  expect_false(has_non_ascii("hello123"))
+})
+
+test_that("has_non_ascii detects accented Latin, CJK, and emoji", {
+  expect_true(has_non_ascii("café"))
+  expect_true(has_non_ascii("北京"))
+  expect_true(has_non_ascii("a🙂"))
+  expect_true(has_non_ascii(c("CTRL", "café")))
+})
+
+test_that("has_non_ascii handles edge inputs", {
+  expect_false(has_non_ascii(NULL))
+  expect_false(has_non_ascii(character(0)))
+  expect_false(has_non_ascii(NA_character_))
+  expect_false(has_non_ascii(""))
+  expect_false(has_non_ascii(c(NA_character_, "")))
+})
+
+# --- sanitize_created_names() (strict wizard sanitizer) ----------------------
+
+test_that("sanitize_created_names keeps ASCII alphanumerics and underscores", {
+  expect_equal(sanitize_created_names("WT_Rep1"), "WT_Rep1")
+  expect_equal(sanitize_created_names("abc123"), "abc123")
+  expect_equal(sanitize_created_names("foo_BAR_42"), "foo_BAR_42")
+})
+
+test_that("sanitize_created_names strips punctuation that sanitize_names preserves", {
+  expect_equal(sanitize_created_names('what?'), "what")
+  expect_equal(sanitize_created_names('say "hi"'), "sayhi")
+  expect_equal(sanitize_created_names("ctrl(rep1)"), "ctrlrep1")
+  expect_equal(sanitize_created_names("a!b@c#d$"), "abcd")
+  expect_equal(sanitize_created_names("foo:bar"), "foobar")
+})
+
+test_that("sanitize_created_names strips spaces, hyphens, dots", {
+  expect_equal(sanitize_created_names("Sample 1"), "Sample1")
+  expect_equal(sanitize_created_names("Sample-1"), "Sample1")
+  expect_equal(sanitize_created_names("Sample.1"), "Sample1")
+})
+
+test_that("sanitize_created_names strips non-ASCII characters", {
+  expect_equal(sanitize_created_names("café"), "caf")
+  expect_equal(sanitize_created_names("北京"), "")
+  expect_equal(sanitize_created_names("a🙂b"), "ab")
+})
+
+test_that("sanitize_created_names preserves NA and handles edge inputs", {
+  expect_equal(sanitize_created_names(NA_character_), NA_character_)
+  expect_equal(
+    sanitize_created_names(c("ok", NA_character_, "bad?")),
+    c("ok", NA_character_, "bad")
+  )
+  expect_null(sanitize_created_names(NULL))
+  expect_equal(sanitize_created_names(character(0)), character(0))
+})
+
+# --- sanitize_names() (original gentle behavior — unchanged contract) --------
+
+test_that("sanitize_names preserves punctuation that the strict variant strips", {
+  # The original sanitize_names only strips control chars, zero-width, NBSP,
+  # hyphens, dots, and whitespace. Everything else passes through.
+  expect_equal(sanitize_names('what?'), "what?")
+  expect_equal(sanitize_names("ctrl(rep1)"), "ctrl(rep1)")
+  expect_equal(sanitize_names("foo:bar"), "foo:bar")
+})
+
+test_that("sanitize_names still strips spaces, hyphens, dots (legacy behavior)", {
+  expect_equal(sanitize_names("Sample 1"), "Sample1")
+  expect_equal(sanitize_names("Sample-1"), "Sample1")
+  expect_equal(sanitize_names("Sample.1"), "Sample1")
+})
+
+test_that("sanitize_names preserves non-ASCII characters", {
+  # Uploaded-file sanitizer is intentionally permissive on Unicode.
+  expect_equal(sanitize_names("café"), "café")
+  expect_equal(sanitize_names("北京"), "北京")
+})


### PR DESCRIPTION
changes to refine the design builder:

- more concise labeling/wording
- typo detection
- only accepts chars A-Z and 0-9
- saves state if user applies a design they made

overall description:

A new "+ Create design" button next to the experiment-file upload opens a modal that lets users build a design without leaving the app or roundtripping through a CSV. The modal has two tabs sharing the same applied state:

Guided: name factors + levels in step 1, click samples to assign them in step 2. Supports paired/blocking factors. Warns on near-duplicate level names and non-ASCII characters.
Manual: free-text 5-row grid. Row 1 auto-fills from detect_groups(). Blocks Apply on near-duplicate cell labels within a factor.
Apply injects the design straight into loaded_data()$sample_info — no download/upload roundtrip. Re-opening after Apply pre-fills both tabs from the current design and lands Guided on step 2. Uploading an experiment file clears the GUI-built design.

New helpers in R/fct_01_load_data.R:

create_design_template(): pre-detect groups from sample names
build_sample_info_from_df(): turn a GUI-built data frame into the sample_info matrix downstream modules expect
sanitize_created_names(): strict [A-Za-z0-9_] sanitizer for user-typed wizard labels (sanitize_names is unchanged and still used for uploaded files)
near_duplicate_pairs(): flag likely typos via Levenshtein <= 1, with carve-outs for numbered series (S1/S2, Rep1/Rep10) and very short labels (length <= 2)
has_non_ascii(): warn on characters that may get rewritten downstream
Tests: test-design_builder.R and test-guided_design_wizard.R